### PR TITLE
Add fallback to vi

### DIFF
--- a/jipdate.py
+++ b/jipdate.py
@@ -64,6 +64,8 @@ def open_editor(filename):
         editor = "/usr/bin/editor"
     elif os.path.exists("/usr/bin/vim"):
         editor = "/usr/bin/vim"
+    elif os.path.exists("/usr/bin/vi"):
+        editor = "/usr/bin/vi"
     else:
         eprint("Could not load an editor.  Please define EDITOR or VISUAL")
         sys.exit()


### PR DESCRIPTION
The traditional fallback editor on Unix systems is vi and there are
non-vim implementations so provide defence in depth.

Signed-off-by: Mark Brown <broonie@kernel.org>