### PR TITLE
Don't ask users for permission to update if there are no updates

### DIFF
--- a/jipdate.py
+++ b/jipdate.py
@@ -326,7 +326,7 @@ def parse_status_file(jira, filename):
     print("")
 
     issue_comments = issue_upload
-    if should_update() == "n":
+    if issue_comments == [] or should_update() == "n":
         print("No change, Jira was not updated!\n")
         print_status(status)
         sys.exit()


### PR DESCRIPTION
If there are no updates we don't need to ask the user for permission to
make them.

Signed-off-by: Mark Brown <broonie@kernel.org>