### PR TITLE
Refactor login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.yml
 status.txt
 *.swp
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config.yml
+.jipdate.yml
 status.txt
 *.swp
 *.pyc

--- a/cfg.py
+++ b/cfg.py
@@ -1,0 +1,7 @@
+TEST_SERVER = 'https://dev-projects.linaro.org'
+PRODUCTION_SERVER = 'https://projects.linaro.org'
+
+args = None
+config_filename = "config.yml"
+server = PRODUCTION_SERVER
+yml_config = None

--- a/cfg.py
+++ b/cfg.py
@@ -1,7 +1,26 @@
+import os
+import sys
+
 TEST_SERVER = 'https://dev-projects.linaro.org'
 PRODUCTION_SERVER = 'https://projects.linaro.org'
+server = PRODUCTION_SERVER
 
 args = None
-config_filename = "config.yml"
-server = PRODUCTION_SERVER
+
+# Config file paths and name, basically we allow the user to store the
+# .config.yml/config.yml in either the application directory, the $HOME
+# directory or the  $HOME/.config/jipdate directory.
+config_app_dir = sys.path[0]
+config_home_config_dir = os.environ['HOME'] + "/.config/jipdate"
+config_home_dir = os.environ['HOME']
+config_locations = [config_app_dir, config_home_dir, config_home_config_dir]
+config_path = config_home_config_dir
+
+# Config filenames
+config_filename = ".jipdate.yml"
+config_legacy_filename = "config.yml"
+
+# Config current file, will be set when initiate the config
+config_file = None
+
 yml_config = None

--- a/helper.py
+++ b/helper.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-
+import sys
 import cfg
 
 def eprint(*args, **kwargs):
@@ -11,5 +11,3 @@ def vprint(*args, **kwargs):
     """ Helper function that prints when verbose has been enabled. """
     if cfg.args.v:
         print(*args, file=sys.stdout, **kwargs)
-
-

--- a/helper.py
+++ b/helper.py
@@ -1,0 +1,15 @@
+from __future__ import print_function
+
+import cfg
+
+def eprint(*args, **kwargs):
+    """ Helper function that prints on stderr. """
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def vprint(*args, **kwargs):
+    """ Helper function that prints when verbose has been enabled. """
+    if cfg.args.v:
+        print(*args, file=sys.stdout, **kwargs)
+
+

--- a/jipdate.py
+++ b/jipdate.py
@@ -301,10 +301,10 @@ def parse_status_file(jira, filename):
 
             if validissue:
                 issue_comments.append((myissue, ""))
-	# Stop parsing entirely.  This needs to be placed before regex_stop
-	# or the .* will match and [FIN] won't be processed
-	elif re.search(regex_fin, line):
-		break
+        # Stop parsing entirely.  This needs to be placed before regex_stop
+        # or the .* will match and [FIN] won't be processed
+        elif re.search(regex_fin, line):
+            break
         # If we have non-JIRA issue tags, stop parsing until we find a valid tag
         elif re.search(regex_stop, line):
                 validissue = False

--- a/jiralogin.py
+++ b/jiralogin.py
@@ -105,7 +105,7 @@ def get_jira_instance(use_test_server):
     try:
         j = JIRA(cfg.server, basic_auth=credentials), username
     except JIRAError, e:
-	if e.text.find('CAPTCHA_CHALLENGE') != -1:
+        if e.text.find('CAPTCHA_CHALLENGE') != -1:
             eprint('Captcha verification has been triggered by '\
                    'JIRA - please go to JIRA using your web '\
                    'browser, log out of JIRA, log back in '\

--- a/jiralogin.py
+++ b/jiralogin.py
@@ -1,0 +1,118 @@
+import os
+import getpass
+
+from helper import *
+from jira import JIRA
+from jira import JIRAError
+
+import cfg
+import helper
+
+def get_username_from_config():
+    """ Get the username for Jira from the config file. """
+    username = None
+    # First check if the username is in the config file.
+    try:
+        username = cfg.yml_config['username']
+    except:
+        vprint("No username found in config")
+
+    return username
+
+
+def get_username_from_env():
+    """ Get the username for Jira from the environment variable. """
+    username = None
+    try:
+        username = os.environ['JIRA_USERNAME']
+    except KeyError:
+        vprint("No user name found in JIRA_USERNAME environment variable")
+
+    return username
+
+
+def get_username_from_input():
+    """ Get the username for Jira from terminal. """
+    username = raw_input("Username (john.doe@foo.org): ").lower().strip()
+    if len(username) == 0:
+        eprint("Empty username not allowed")
+        sys.exit(os.EX_NOUSER)
+    else:
+        return username
+
+
+def store_username_in_config(username):
+    """ Append the username to the config file. """
+    # Needs global variable or arg instead.
+    config_file = "config.yml"
+    with open(config_file, 'a') as f:
+        f.write("\nusername: %s" % username)
+
+
+
+def get_username():
+    """ Main function to get the username from various places. """
+    username = get_username_from_env() or \
+               get_username_from_config()
+
+    if username is not None:
+        return username
+
+    username = get_username_from_input()
+
+    if username is not None:
+        answer = raw_input("Username not found in config.yml, want to store " + \
+                           "it? (y/n) ").lower().strip()
+        if answer in set(['y']):
+            store_username_in_config(username)
+        return username
+    else:
+        eprint("No JIRA_USERNAME exported and no username found in config.yml")
+        sys.exit(os.EX_NOUSER)
+
+
+def get_password():
+    """
+    Get the password either from the environment variable or from the
+    terminal.
+    """
+    try:
+        password = os.environ['JIRA_PASSWORD']
+        return password
+    except KeyError:
+        vprint("Forgot to export JIRA_PASSWORD?")
+
+    password = getpass.getpass()
+    if len(password) == 0:
+        eprint("JIRA_PASSWORD not exported or empty password provided")
+        sys.exit(os.EX_NOPERM)
+
+    return password
+
+
+def get_jira_instance(use_test_server):
+    """
+    Makes a connection to the Jira server and returns the Jira instance to the
+    caller.
+    """
+    username = get_username()
+    password = get_password()
+
+    credentials=(username, password)
+
+    if use_test_server:
+        cfg.server = cfg.TEST_SERVER
+
+    try:
+        j = JIRA(cfg.server, basic_auth=credentials), username
+    except JIRAError, e:
+	if e.text.find('CAPTCHA_CHALLENGE') != -1:
+            eprint('Captcha verification has been triggered by '\
+                   'JIRA - please go to JIRA using your web '\
+                   'browser, log out of JIRA, log back in '\
+                   'entering the captcha; after that is done, '\
+                   'please re-run the script')
+            sys.exit(os.EX_NOPERM)
+        else:
+            raise
+    return j

--- a/jiralogin.py
+++ b/jiralogin.py
@@ -44,10 +44,8 @@ def get_username_from_input():
 def store_username_in_config(username):
     """ Append the username to the config file. """
     # Needs global variable or arg instead.
-    config_file = "config.yml"
-    with open(config_file, 'a') as f:
+    with open(cfg.config_file, 'a') as f:
         f.write("\nusername: %s" % username)
-
 
 
 def get_username():
@@ -61,8 +59,9 @@ def get_username():
     username = get_username_from_input()
 
     if username is not None:
-        answer = raw_input("Username not found in config.yml, want to store " + \
-                           "it? (y/n) ").lower().strip()
+        question = "Username not found in %s, want to store it? (y/n) " % \
+                        cfg.config_file
+        answer = raw_input(question).lower().strip()
         if answer in set(['y']):
             store_username_in_config(username)
         return username


### PR DESCRIPTION
Some misc fixes here, I've split up the script into a few more python files. This makes configuration a bit more clear and also makes it possible to share functionality (Jira login procedure, vprint, eprint etc) with other scripts (I have other scripts coming ...) in the future.

Then there is one patch that enables the user to store his config file in either the script-dir, `$HOME` or `$HOME/.config/jipdate`, i.e., that should fix #18 .

@chazy @pm215 would you mind giving this a try (and eventually review if you have time) before merging.

// Jocke