### PR TITLE
jipdate: fix open_editor when EDITOR has args

### DIFF
--- a/jipdate.py
+++ b/jipdate.py
@@ -44,7 +44,7 @@ def open_editor(filename):
         eprint("Could not load an editor.  Please define EDITOR or VISUAL")
         sys.exit(os.EX_CONFIG)
 
-    call([editor, filename])
+    call(editor.split() + [filename])
 
 
 def open_file(filename):


### PR DESCRIPTION
If EDITOR is set to 'emacs -nw', which is a valid configuration,
open_editor() fails to open the editor and aborts with:

Traceback (most recent call last):
  File "./jipdate.py", line 459, in <module>
    main(sys.argv)
  File "./jipdate.py", line 455, in main
    open_editor(filename)
  File "./jipdate.py", line 48, in open_editor
    call([editor, filename])
  File "/usr/lib/python2.7/subprocess.py", line 172, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 394, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1047, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

So assuming that editor can be a prog name and args, we can split 'editor' before using
it.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>