### PR TITLE
jipdate: search_issues() might return only a subset of items

### DIFF
--- a/jipdate.py
+++ b/jipdate.py
@@ -201,6 +201,8 @@ def get_jira_issues(jira, username):
     vprint(jql)
 
     my_issues = jira.search_issues(jql)
+    if my_issues.total > my_issues.maxResults:
+        my_issues = jira.search_issues(jql, maxResults=my_issues.total)
 
     showdate = strftime("%Y-%m-%d", gmtime())
     subject = "Subject: [Weekly] Week ending " + showdate + "\n\n"


### PR DESCRIPTION
search_issues() will return maxResults items, which defaults to 50. If
there are more than maxResults items in the query they are currently
ignored. Total number of results is available in the total attribute
of the returned ResultList, so run again the query to get all items,
if needed.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>