### PR TITLE
Add jipstatus tool

### DIFF
--- a/jipstatus.py
+++ b/jipstatus.py
@@ -36,8 +36,7 @@ def enumerate_updates(jira):
     since = datetime.datetime.now() - datetime.timedelta(days=int(cfg.args.days))
 
     jql = "updatedDate > -%sd" % cfg.args.days
-    if user:
-       jql += ' AND assignee = "%s"' % add_domain(user)
+    jql += ' AND assignee = "%s"' % add_domain(user)
     if project:
        jql += ' AND project = "%s"' % project
     vprint(jql)
@@ -92,8 +91,7 @@ def enumerate_pending(jira):
     jql = "status = 'In Progress' \
            AND issuetype != Initiative \
            AND issuetype != Epic"
-    if user:
-       jql += ' AND assignee = "%s"' % add_domain(user)
+    jql += ' AND assignee = "%s"' % add_domain(user)
     if project:
        jql += ' AND project = "%s"' % project
     vprint(jql)
@@ -233,6 +231,9 @@ def main(argv):
     cfg.initiate_config()
 
     jira, username = jiralogin.get_jira_instance(cfg.args.t)
+
+    if cfg.args.user is None:
+        cfg.args.user = username
 
     updates = list(enumerate_updates(jira))
     pendings = list(enumerate_pending(jira))

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -29,16 +29,22 @@ def add_domain(user):
         user = user + "@linaro.org"
     return user
 
-def enumerate_updates(jira):
+def default_jql():
     user = cfg.args.user
     project = cfg.args.project
 
+    if project:
+        jql = "project =  '%s' " % project
+    else:
+        jql = "assignee = '%s' " % add_domain(user)
+
+    return jql
+
+def enumerate_updates(jira):
     since = datetime.datetime.now() - datetime.timedelta(days=int(cfg.args.days))
 
-    jql = "updatedDate > -%sd" % cfg.args.days
-    jql += ' AND assignee = "%s"' % add_domain(user)
-    if project:
-       jql += ' AND project = "%s"' % project
+    jql = default_jql()
+    jql += "AND updatedDate > -%sd" % cfg.args.days
     vprint(jql)
 
     my_issues = jira.search_issues(jql, expand="changelog", fields="summary,comment,assignee,created")
@@ -83,17 +89,12 @@ def enumerate_updates(jira):
             yield(status)
 
 def enumerate_pending(jira):
-    user = cfg.args.user
-    project = cfg.args.project
-
     since = datetime.datetime.now() - datetime.timedelta(days=7)
 
-    jql = "status = 'In Progress' \
-           AND issuetype != Initiative \
-           AND issuetype != Epic"
-    jql += ' AND assignee = "%s"' % add_domain(user)
-    if project:
-       jql += ' AND project = "%s"' % project
+    jql = default_jql()
+    jql += "AND status = 'In Progress' \
+            AND issuetype != Initiative \
+            AND issuetype != Epic"
     vprint(jql)
 
     my_issues = jira.search_issues(jql, expand="changelog", fields="summary,assignee,created")

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -31,12 +31,15 @@ def add_domain(user):
 
 def enumerate_updates(jira):
     user = cfg.args.user
+    project = cfg.args.project
 
     since = datetime.datetime.now() - datetime.timedelta(days=int(cfg.args.days))
 
-    jql = "(project = QLT OR assignee in membersOf('linaro-landing-team-qualcomm')) AND updatedDate > -%sd" % cfg.args.days
+    jql = "updatedDate > -%sd" % cfg.args.days
     if user:
        jql += ' AND assignee = "%s"' % add_domain(user)
+    if project:
+       jql += ' AND project = "%s"' % project
     vprint(jql)
 
     my_issues = jira.search_issues(jql, expand="changelog", fields="summary,comment,assignee,created")
@@ -82,15 +85,17 @@ def enumerate_updates(jira):
 
 def enumerate_pending(jira):
     user = cfg.args.user
+    project = cfg.args.project
 
     since = datetime.datetime.now() - datetime.timedelta(days=7)
 
-    jql = "(project = QLT OR assignee in membersOf('linaro-landing-team-qualcomm')) \
-           AND status = 'In Progress' \
+    jql = "status = 'In Progress' \
            AND issuetype != Initiative \
            AND issuetype != Epic"
     if user:
        jql += ' AND assignee = "%s"' % add_domain(user)
+    if project:
+       jql += ' AND project = "%s"' % project
     vprint(jql)
 
     my_issues = jira.search_issues(jql, expand="changelog", fields="summary,assignee,created")
@@ -127,6 +132,11 @@ def get_parser():
             default=None, \
             help='Query Jira with another Jira username \
             (first.last or first.last@linaro.org)')
+
+    parser.add_argument('-p', '--project', required=False, action="store", \
+            default=None, \
+            type = str.upper, \
+            help='Query Jira for only a specifc project')
 
     parser.add_argument('--days', required=False, action="store", \
             default=7, \

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -152,7 +152,7 @@ output = """
 {%- if loop.index == 1 %}
  * Past
 {%- endif %}
-   * {{issue['summary']}} ({{issue['issue']}}) {% if issue['resolution'] %}was {{issue['resolution']}}{% endif %}
+   * [{{issue['issue']}}] {{issue['summary']}} {% if issue['resolution'] %}- was {{issue['resolution']|lower}}{% endif %}
   {%- for c in issue['comments'] %}
     {%- for cc in c.splitlines() %}
     {% if loop.index == 1 %} *{% else %}  {% endif %} {{cc}}
@@ -163,7 +163,7 @@ output = """
 {%- if loop.index == 1 %}
  * Ongoing
 {%- endif %}
-   * {{issue['summary']}} ({{issue['issue']}})
+   * [{{issue['issue']}}] {{issue['summary']}}
  {%- endfor %}
 {% endfor %}
 """
@@ -179,7 +179,7 @@ output_html = """
 <li>Past</li>
     <ul>
 {%- endif %}
-        <li>{{issue['summary']}} (<a href="https://projects.linaro.org/browse/{{issue['issue']}}">{{issue['issue']}}</a>) {% if issue['resolution'] %}was {{issue['resolution']}}{% endif %}</li>
+        <li>[<a href="https://projects.linaro.org/browse/{{issue['issue']}}">{{issue['issue']}}</a>] {{issue['summary']}} {% if issue['resolution'] %} - was {{issue['resolution']|lower}}{% endif %}</li>
         {%- for c in issue['comments'] %}
         {%- if loop.index == 1 %}
             <ul>
@@ -198,7 +198,7 @@ output_html = """
 <li>Ongoing</li>
     <ul>
 {%- endif %}
-        <li>{{issue['summary']}} (<a href="https://projects.linaro.org/browse/{{issue['issue']}}">{{issue['issue']}}</a>)</li>
+        <li>[<a href="https://projects.linaro.org/browse/{{issue['issue']}}">{{issue['issue']}}</a>] {{issue['summary']}}</li>
 {%- if loop.index == loop.length %}
     </ul>
 {%- endif %}

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+from subprocess import call
+from time import gmtime, strftime
+
+import json
+import os
+import re
+import sys
+import tempfile
+import yaml
+import datetime
+
+# Local files
+import cfg
+from helper import vprint, eprint
+import jiralogin
+
+import pprint
+pprint = pprint.PrettyPrinter().pprint
+
+def enumerate_updates(jira):
+    since = datetime.datetime.now() - datetime.timedelta(days=7)
+
+    jql = "project = QLT AND updatedDate > -7d"
+    vprint(jql)
+
+    my_issues = jira.search_issues(jql, expand="changelog", fields="summary,comment,assignee,created")
+    for issue in my_issues:
+        changelog = issue.changelog
+        comments = issue.fields.comment.comments
+
+        status = {}
+        status['issue'] = str(issue)
+        if issue.fields.assignee:
+            status['assignee'] = issue.fields.assignee.displayName
+        else:
+            status['assignee'] = 'Unassigned'
+        status['summary'] = issue.fields.summary
+        status['comments'] = []
+        status['resolution'] = None
+
+        created = datetime.datetime.strptime(issue.fields.created, '%Y-%m-%dT%H:%M:%S.%f%z')
+        if created.replace(tzinfo=None) > since:
+            status['resolution'] = 'Created'
+
+        for comment in comments:
+            when = datetime.datetime.strptime(comment.created, '%Y-%m-%dT%H:%M:%S.%f%z')
+            if when.replace(tzinfo=None) < since:
+                continue
+
+            status['comments'].append(comment.body)
+
+        for history in changelog.histories:
+            for item in history.items:
+                if item.field == 'resolution':
+                    status['resolution'] = item.toString
+
+        yield(status)
+
+def enumerate_pending(jira):
+    since = datetime.datetime.now() - datetime.timedelta(days=7)
+
+    jql = 'project = QLT AND status = "In Progress"'
+    vprint(jql)
+
+    my_issues = jira.search_issues(jql, expand="changelog", fields="summary,assignee,created")
+    for issue in my_issues:
+        status = {}
+        status['issue'] = str(issue)
+        if issue.fields.assignee:
+            status['assignee'] = issue.fields.assignee.displayName
+        else:
+            status['assignee'] = 'Unassigned'
+        status['summary'] = issue.fields.summary
+
+        created = datetime.datetime.strptime(issue.fields.created, '%Y-%m-%dT%H:%M:%S.%f%z')
+        status['new'] = created.replace(tzinfo=None) > since
+
+        yield(status)
+
+################################################################################
+# Argument parser
+################################################################################
+def get_parser():
+    """ Takes care of script argument parsing. """
+    parser = ArgumentParser(description='Script used to update comments in Jira')
+
+    parser.add_argument('-t', required=False, action="store_true", \
+            default=False, \
+            help='Use the test server')
+
+    parser.add_argument('-u', '--user', required=False, action="store", \
+            default=None, \
+            help='Query Jira with another Jira username \
+            (first.last or first.last@linaro.org)')
+
+    parser.add_argument('-v', required=False, action="store_true", \
+            default=False, \
+            help='Output some verbose debugging info')
+
+    return parser
+
+################################################################################
+# Main function
+################################################################################
+def main(argv):
+    parser = get_parser()
+
+    # The parser arguments (cfg.args) are accessible everywhere after this call.
+    cfg.args = parser.parse_args()
+
+    # This initiates the global yml configuration instance so it will be
+    # accessible everywhere after this call.
+    cfg.initiate_config()
+
+    jira, username = jiralogin.get_jira_instance(cfg.args.t)
+
+    updates = list(enumerate_updates(jira))
+    pendings = list(enumerate_pending(jira))
+
+    assignees = sorted(set([u['assignee'] for u in updates]) | set([p['assignee'] for p in pendings]))
+    # Move "Unassigned" issues to the end
+    assignees.sort(key='Unassigned'.__eq__)
+
+    for assignee in assignees:
+        print("%s:" % assignee)
+
+        issues = [u for u in updates if u['assignee'] == assignee]
+        if len(issues) > 0:
+            print(' * Past')
+            for issue in issues:
+                if issue['resolution']:
+                    event = 'was %s' % issue['resolution']
+                else:
+                    event = ''
+
+                print("   * %s (%s) %s" % (issue['summary'], issue['issue'], event))
+                if len(issue['comments']) > 0:
+                    print("     * %s" % "\n       ".join(issue['comments'][-1].splitlines()))
+
+        issues = [p for p in pendings if p['assignee'] == assignee]
+        if len(issues) > 0:
+            print(' * Ongoing')
+            for issue in issues:
+                print("   * %s (%s)" % (issue['summary'], issue['issue']))
+
+        print('')
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -76,7 +76,8 @@ def enumerate_updates(jira):
                 if item.field == 'resolution':
                     status['resolution'] = item.toString
 
-        yield(status)
+        if len(status['comments']) != 0 or status['resolution']:
+            yield(status)
 
 def enumerate_pending(jira):
     user = cfg.args.user

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -184,7 +184,7 @@ output_html = """
         {%- if loop.index == 1 %}
             <ul>
         {%- endif %}
-                <li>{{c}}</li>
+                <li>{{'<br>'.join(c.splitlines())}}</li>
         {%- if loop.index == loop.length %}
             </ul>
         {%- endif %}

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -32,8 +32,13 @@ def add_domain(user):
 def default_jql():
     user = cfg.args.user
     project = cfg.args.project
+    team = cfg.args.team
 
-    if project:
+    if team and project:
+        jql = "(project = %s or assignee in membersOf('%s')) " % (project, team)
+    elif team:
+        jql = "assignee in membersOf('%s') " % team
+    elif project:
         jql = "project =  '%s' " % project
     else:
         jql = "assignee = '%s' " % add_domain(user)
@@ -123,7 +128,7 @@ def get_parser():
     """ Takes care of script argument parsing. """
     parser = ArgumentParser(description='Script used to update comments in Jira')
 
-    parser.add_argument('-t', required=False, action="store_true", \
+    parser.add_argument('--test', required=False, action="store_true", \
             default=False, \
             help='Use the test server')
 
@@ -136,6 +141,11 @@ def get_parser():
             default=None, \
             type = str.upper, \
             help='Query Jira for only a specifc project')
+
+    parser.add_argument('-t', '--team', required=False, action="store", \
+            default=None, \
+            type = str.lower, \
+            help='Query Jira for only issues assigned to members of a specific tema (eg. linaro-landing-team-qualcomm)')
 
     parser.add_argument('--days', required=False, action="store", \
             default=7, \
@@ -231,7 +241,7 @@ def main(argv):
     # accessible everywhere after this call.
     cfg.initiate_config()
 
-    jira, username = jiralogin.get_jira_instance(cfg.args.t)
+    jira, username = jiralogin.get_jira_instance(cfg.args.test)
 
     if cfg.args.user is None:
         cfg.args.user = username

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -19,10 +19,23 @@ import jiralogin
 import pprint
 pprint = pprint.PrettyPrinter().pprint
 
+def add_domain(user):
+    """
+    Helper function that appends @linaro.org to the username. It does nothing if
+    it is already included.
+    """
+    if '@' not in user:
+        user = user + "@linaro.org"
+    return user
+
 def enumerate_updates(jira):
+    user = cfg.args.user
+
     since = datetime.datetime.now() - datetime.timedelta(days=7)
 
     jql = "project = QLT AND updatedDate > -7d"
+    if user:
+       jql += ' AND assignee = "%s"' % add_domain(user)
     vprint(jql)
 
     my_issues = jira.search_issues(jql, expand="changelog", fields="summary,comment,assignee,created")
@@ -59,9 +72,13 @@ def enumerate_updates(jira):
         yield(status)
 
 def enumerate_pending(jira):
+    user = cfg.args.user
+
     since = datetime.datetime.now() - datetime.timedelta(days=7)
 
     jql = 'project = QLT AND status = "In Progress"'
+    if user:
+       jql += ' AND assignee = "%s"' % add_domain(user)
     vprint(jql)
 
     my_issues = jira.search_issues(jql, expand="changelog", fields="summary,assignee,created")

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -33,7 +33,7 @@ def enumerate_updates(jira):
 
     since = datetime.datetime.now() - datetime.timedelta(days=7)
 
-    jql = "project = QLT AND updatedDate > -7d"
+    jql = "(project = QLT OR assignee in membersOf('linaro-landing-team-qualcomm')) AND updatedDate > -7d"
     if user:
        jql += ' AND assignee = "%s"' % add_domain(user)
     vprint(jql)
@@ -80,7 +80,7 @@ def enumerate_pending(jira):
 
     since = datetime.datetime.now() - datetime.timedelta(days=7)
 
-    jql = 'project = QLT AND status = "In Progress"'
+    jql = "(project = QLT OR assignee in membersOf('linaro-landing-team-qualcomm')) AND status = 'In Progress'"
     if user:
        jql += ' AND assignee = "%s"' % add_domain(user)
     vprint(jql)

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -69,6 +69,9 @@ def enumerate_updates(jira):
             status['comments'].append(comment.body)
 
         for history in changelog.histories:
+            when = datetime.datetime.strptime(history.created, '%Y-%m-%dT%H:%M:%S.%f%z')
+            if when.replace(tzinfo=None) < since:
+                continue
             for item in history.items:
                 if item.field == 'resolution':
                     status['resolution'] = item.toString

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -32,9 +32,9 @@ def add_domain(user):
 def enumerate_updates(jira):
     user = cfg.args.user
 
-    since = datetime.datetime.now() - datetime.timedelta(days=7)
+    since = datetime.datetime.now() - datetime.timedelta(days=int(cfg.args.days))
 
-    jql = "(project = QLT OR assignee in membersOf('linaro-landing-team-qualcomm')) AND updatedDate > -7d"
+    jql = "(project = QLT OR assignee in membersOf('linaro-landing-team-qualcomm')) AND updatedDate > -%sd" % cfg.args.days
     if user:
        jql += ' AND assignee = "%s"' % add_domain(user)
     vprint(jql)
@@ -127,6 +127,10 @@ def get_parser():
             default=None, \
             help='Query Jira with another Jira username \
             (first.last or first.last@linaro.org)')
+
+    parser.add_argument('--days', required=False, action="store", \
+            default=7, \
+            help='Period of the report in days')
 
     parser.add_argument('--html', required=False, nargs='?', action="store", \
             const='status.html', \

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -39,6 +39,10 @@ def enumerate_updates(jira):
     vprint(jql)
 
     my_issues = jira.search_issues(jql, expand="changelog", fields="summary,comment,assignee,created")
+    if my_issues.total > my_issues.maxResults:
+        my_issues = jira.search_issues(jql, expand="changelog", fields="summary,comment,assignee,created",
+                                       maxResults=my_issues.total)
+
     for issue in my_issues:
         changelog = issue.changelog
         comments = issue.fields.comment.comments
@@ -82,6 +86,10 @@ def enumerate_pending(jira):
     vprint(jql)
 
     my_issues = jira.search_issues(jql, expand="changelog", fields="summary,assignee,created")
+    if my_issues.total > my_issues.maxResults:
+        my_issues = jira.search_issues(jql, expand="changelog", fields="summary,assignee,created",
+                                       maxResults=my_issues.total)
+
     for issue in my_issues:
         status = {}
         status['issue'] = str(issue)

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -179,7 +179,7 @@ output_html = """
 <li>Past</li>
     <ul>
 {%- endif %}
-        <li>{{issue['summary']}} ({{issue['issue']}}) {% if issue['resolution'] %}was {{issue['resolution']}}{% endif %}</li>
+        <li>{{issue['summary']}} (<a href="https://projects.linaro.org/browse/{{issue['issue']}}">{{issue['issue']}}</a>) {% if issue['resolution'] %}was {{issue['resolution']}}{% endif %}</li>
         {%- for c in issue['comments'] %}
         {%- if loop.index == 1 %}
             <ul>
@@ -198,7 +198,7 @@ output_html = """
 <li>Ongoing</li>
     <ul>
 {%- endif %}
-        <li>{{issue['summary']}} ({{issue['issue']}})</li>
+        <li>{{issue['summary']}} (<a href="https://projects.linaro.org/browse/{{issue['issue']}}">{{issue['issue']}}</a>)</li>
 {%- if loop.index == loop.length %}
     </ul>
 {%- endif %}

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -161,8 +161,11 @@ def main(argv):
                     event = ''
 
                 print("   * %s (%s) %s" % (issue['summary'], issue['issue'], event))
-                if len(issue['comments']) > 0:
-                    print("     * %s" % "\n       ".join(issue['comments'][-1].splitlines()))
+                for c in issue['comments']:
+                    cc = c.splitlines()
+                    print("     * " + cc[0])
+                    for cc_line in cc[1:]:
+                        print("       " + cc_line)
 
         issues = [p for p in pendings if p['assignee'] == assignee]
         if len(issues) > 0:

--- a/jipstatus.py
+++ b/jipstatus.py
@@ -84,7 +84,10 @@ def enumerate_pending(jira):
 
     since = datetime.datetime.now() - datetime.timedelta(days=7)
 
-    jql = "(project = QLT OR assignee in membersOf('linaro-landing-team-qualcomm')) AND status = 'In Progress'"
+    jql = "(project = QLT OR assignee in membersOf('linaro-landing-team-qualcomm')) \
+           AND status = 'In Progress' \
+           AND issuetype != Initiative \
+           AND issuetype != Epic"
     if user:
        jql += ' AND assignee = "%s"' % add_domain(user)
     vprint(jql)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jira
 pyyaml
+Jinja2


### PR DESCRIPTION
This tool supports creating both ASCII & HTML reports of Jira tasks & events for the past few days.
The HTML output provides clickable ticket links.

```
usage: jipstatus.py [-h] [-t] [-u USER] [--days DAYS] [--html [HTML]] [-v]

Script used to update comments in Jira

optional arguments:
  -h, --help            show this help message and exit
  -t                    Use the test server
  -u USER, --user USER  Query Jira with another Jira username (first.last or first.last@linaro.org)
  --days DAYS           Period of the report in days
  --html [HTML]         Store output to HTML file
  -v                    Output some verbose debugging info
```


```
$ ./jipstatus.py -u robert.foss --days 7                  

Robert Foss:
 * Past
   * [QLT-1121] lt9611 drm/bridge does not reject invalid modes 
     * Pinged maintainers about merging this patch
   * [CAM-76] db845c: ov8856 dt node misconfigures gpio - was delivered
     * Merged
       https://git.kernel.org/pub/scm/linux/kernel/git/qcom/linux.git/commit/?id=d4863ef399a2
   * [CAM-73] ov8856: Fix bad Bayer mode 
     * Submitted v4
       https://patchwork.kernel.org/project/linux-media/patch/20210118190132.1045913-1-robert.foss@linaro.org/
     * Submitted v5
       https://lkml.org/lkml/2021/1/20/391
   * [CAM-69] Upstream CAMSS SDM845 
     * Submitted v2
       https://patchwork.kernel.org/project/linux-media/list/?series=418233
 * Ongoing
   * [QLT-1121] lt9611 drm/bridge does not reject invalid modes
   * [CAM-73] ov8856: Fix bad Bayer mode
   * [CAM-69] Upstream CAMSS SDM845
```