### PR TITLE
WIP: jiralogin: Add support for token_auth authentication

### DIFF
--- a/cfg.py
+++ b/cfg.py
@@ -39,12 +39,14 @@ version: 1
 
 # Jira server information
 #server:
-#  url: https://linaro.atlassian.net
-#  token: abcdefghijkl
+#  url: https://issues.redhat.com
+#  token: abcdefghijkl  # Jira Cloud Token
+#  token_auth: abcdefghijkl # Jira Personal Access Token
 
 #test_server:
 #  url: https://<name_of_test_instance>.atlassian.net
-#  token: abcdefghijkl
+#  token: abcdefghijkl  # Jira Cloud Token
+#  token_auth: abcdefghijkl # Jira Personal Access Token
 
 # Extra comments added to each Jira issue (multiline is OK)
 comments:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -35,11 +35,13 @@ looks like this:
     # Jira server information
     #server:
     #  url: https://linaro.atlassian.net
-    #  token: abcdefghijkl
+    #  token: abcdefghijkl  # Jira Cloud Token
+    #  token_auth: abcdefghijkl # Jira Personal Access Token
 
     #test_server:
     #  url: https://<name_of_test_instance>.atlassian.net
-    #  token: abcdefghijkl
+    #  token: abcdefghijkl  # Jira Cloud Token
+    #  token_auth: abcdefghijkl # Jira Personal Access Token
 
     # Extra comments added to each Jira issue (multiline is OK)
     comments:

--- a/jiralogin.py
+++ b/jiralogin.py
@@ -98,14 +98,18 @@ def get_jira_instance(use_test_server):
     server = cfg.get_server(use_test_server)
     url = server.get('url')
     token = server.get('token')
+    token_auth = server.get('token_auth')
 
     # password based authentication
-    if not token:
+    if not (token or token_auth):
         password = get_password()
 
     try:
-        if token:
-            log.debug("Accessing %s with %s using token based authentication" % (url, username))
+        if token_auth:
+            log.debug("Accessing %s with %s using personal access token authentication" % (url, username))
+            j = JIRA(url, token_auth=(token_auth)), username
+        elif token:
+            log.debug("Accessing %s with %s using cloud token authentication" % (url, username))
             j = JIRA(url, basic_auth=(username, token)), username
         else:
             log.debug("Accessing %s with %s using password based authentication" % (url, username))


### PR DESCRIPTION
Self-hosted Jira instances can't use the API token authentication, but must instead rely on the Personal Access Token authentication scheme[1].

This patch introduces support for this authentication method as the third mode of authenticating.

[1] https://jira.readthedocs.io/examples.html#token-auth

---

This PR is missing a convenient way to specify that this login method is the desired one. Something along the lines of

`jipdate --init --auth auth_token/token/password --token abcdefghjkl --server jira.company.com`


Personally find the python-jira nomenclature around token/auth_token to be quite confusing so maybe referring to the different tokens as `cloud_token` and `personal_token` would make more sense.