### PR TITLE
jipdate: add missing Task type

### DIFF
--- a/jipdate/jipdate.py
+++ b/jipdate/jipdate.py
@@ -256,7 +256,7 @@ def get_jira_issues(jira, username):
     if not epics_only:
         issue_types.append("Initiative")
         if not exclude_stories:
-            issue_types.extend(["Story", "Sub-task", "Bug"])
+            issue_types.extend(["Story", "Task", "Sub-task", "Bug"])
     issue_type = "issuetype in (%s)" % ", ".join(issue_types)
 
     status = 'status in ("In Progress")'


### PR DESCRIPTION
Task is missing for the list, so issues of this type are not listed properly.