### PR TITLE
[jipcreate] Fix creating sub-task cards

### DIFF
--- a/jipdate/jipcreate.py
+++ b/jipdate/jipcreate.py
@@ -186,6 +186,9 @@ def main():
                     else:
                         fields["customfield_10014"] = issue["EpicLink"]
 
+                if "Parent" in issue.keys():
+                    fields["parent"] = {"key" : issue["Parent"]}
+
                 if "ClientStakeholder" in issue.keys():
                     csh_fields_dict = issue_meta_data["projects"][0]["issuetypes"][0][
                         "fields"


### PR DESCRIPTION
Sub-task cards need specification of fields.parent.key, which this patch adds.  For refernce, this is how one creates a sub-task card: ===
- IssueType: Sub-task Project: GNU Parent: GNU-835 Summary: Test1 ===