### PR TITLE
jipsearch: Fixed multiple -k attributes on command line

### DIFF
--- a/jipdate/jipsearch.py
+++ b/jipdate/jipsearch.py
@@ -223,8 +223,10 @@ def create_jql(jira, initial_jql):
         jql_parts.append(initial_jql)
 
     if cfg.args.key:
-        for v in cfg.args.key:
-            jql_parts.append(f"key={v}")
+        key_parts = f"key in ({cfg.args.key[0]}"
+        for v in cfg.args.key[1:]:
+            key_parts += f", {v}"
+        jql_parts.append(f"{key_parts})")
 
     if cfg.args.project:
         jql_parts.append("project in (%s)" % cfg.args.project)


### PR DESCRIPTION
When specifying more than one issue key with --key in jipsearch they were ANDed together. Fixed so that they are now in a key in (key1, key2,...) statement.