### PR TITLE
jiralogin: workaround python jira bug

### DIFF
--- a/jipdate/jiralogin.py
+++ b/jipdate/jiralogin.py
@@ -110,13 +110,31 @@ def get_jira_instance(use_test_server):
                 "Accessing %s with %s using token based authentication"
                 % (url, username)
             )
-            j = JIRA(url, basic_auth=(username, token)), username
+            j = (
+                JIRA(
+                    url,
+                    basic_auth=(username, token),
+                    options={
+                        "headers": {"Accept": "application/json;1=1.0, */*;q=0.9"}
+                    },
+                ),
+                username,
+            )
         else:
             log.debug(
                 "Accessing %s with %s using password based authentication"
                 % (url, username)
             )
-            j = JIRA(url, basic_auth=(username, password)), username
+            j = (
+                JIRA(
+                    url,
+                    basic_auth=(username, password),
+                    options={
+                        "headers": {"Accept": "application/json;1=1.0, */*;q=0.9"}
+                    },
+                ),
+                username,
+            )
     except JIRAError as e:
         if e.text.find("CAPTCHA_CHALLENGE") != -1:
             log.error(


### PR DESCRIPTION
Looks like its a bug in Atlassian this was shown.
An issue has been created in the python jira library.

Until its fixed upstream we add this workaround when authenticate in JIRA with user/pass.

Link: https://community.developer.atlassian.com/t/http-406-status-code-from-rest-api-3-resolution-search/75381/5
Link: https://github.com/pycontribs/jira/issues/1774
Suggested-by: Julianus Larson <julianus.larson@linaro.org>