### PR TITLE
jipcreate: check sprint if kanban board

### DIFF
--- a/jipdate/__init__.py
+++ b/jipdate/__init__.py
@@ -1,4 +1,5 @@
 """
 Command line tool for Jira
 """
+
 __version__ = "2.0.3"

--- a/jipdate/jipcreate.py
+++ b/jipdate/jipcreate.py
@@ -223,6 +223,8 @@ def main():
                     log.debug(f"Boards:")
                     for board in boards_in_project:
                         log.debug(f"* {board}")
+                        if board.type == "kanban":
+                            continue
                         sprints_in_board = jira.sprints(board_id=board.id)
                         log.debug(f" + Sprints:")
                         for sprint in sprints_in_board:


### PR DESCRIPTION
Sprint does not exist for kanban boards. We can't check for it.